### PR TITLE
fix: keep completed parents when auto-tracking episodes

### DIFF
--- a/src/app-controller.js
+++ b/src/app-controller.js
@@ -293,7 +293,7 @@ const AppController = (() => {
     // Propagate to Season
     if (seasonId) {
       const seasonStatus = Store.getStatus("season", seasonId);
-      if (seasonStatus !== STATE_WATCHING) {
+      if (seasonStatus === STATE_UNTRACKED) {
         const extraFields = {};
         if (seriesId) {
           extraFields.series_id = seriesId;
@@ -302,24 +302,20 @@ const AppController = (() => {
         extraFields.name = seasonName;
 
         await Store.setState("season", seasonId, STATE_WATCHING, extraFields);
-        if (seasonStatus === STATE_UNTRACKED) {
-          UIManager.showToast(I18n.t("toastAutoTrackSeason", { seasonName }));
-        }
+        UIManager.showToast(I18n.t("toastAutoTrackSeason", { seasonName }));
       }
     }
 
     // Propagate to Series
     if (seriesId) {
       const seriesStatus = Store.getStatus("series", seriesId);
-      if (seriesStatus !== STATE_WATCHING) {
+      if (seriesStatus === STATE_UNTRACKED) {
         const extraFields = {};
         const seriesName = PathAnalyzer.formatSeriesName(seriesId) || "Unknown Series";
         extraFields.name = seriesName;
 
         await Store.setState("series", seriesId, STATE_WATCHING, extraFields);
-        if (seriesStatus === STATE_UNTRACKED) {
-          UIManager.showToast(I18n.t("toastAutoTrackSeries", { seriesName }));
-        }
+        UIManager.showToast(I18n.t("toastAutoTrackSeries", { seriesName }));
       }
     }
   };
@@ -741,6 +737,6 @@ const AppController = (() => {
 
   window.addEventListener("pagehide", teardown);
 
-  return { init, teardown };
+  return { init, teardown, __testables: { propagateWatchingState } };
 })();
 export default AppController;

--- a/tests/unit/app-controller.test.mjs
+++ b/tests/unit/app-controller.test.mjs
@@ -1,0 +1,172 @@
+import { jest } from "@jest/globals";
+import { STATE_COMPLETED, STATE_UNTRACKED, STATE_WATCHING } from "../../src/constants.js";
+
+const utilsModuleMock = {
+  default: {
+    $: jest.fn(() => null),
+    $$: jest.fn(() => []),
+  },
+};
+
+const storeModuleMock = {
+  default: {
+    getStatus: jest.fn(),
+    setState: jest.fn(() => Promise.resolve()),
+    remove: jest.fn(() => Promise.resolve()),
+    getEpisodesBySeasonAndState: jest.fn(() => []),
+    getSeasonsBySeriesAndState: jest.fn(() => []),
+    getEpisodesBySeriesAndState: jest.fn(() => []),
+    getSeasonsForSeries: jest.fn(() => Promise.resolve([])),
+    getEpisodesForSeason: jest.fn(() => Promise.resolve([])),
+    get: jest.fn(() => ({})),
+    subscribe: jest.fn(),
+    load: jest.fn(() => Promise.resolve()),
+    getUserLang: jest.fn(() => "en"),
+    isRowHighlightOn: jest.fn(() => false),
+    receiveSync: jest.fn(() => Promise.resolve()),
+  },
+};
+
+const settingsModuleMock = {
+  default: {
+    createButton: jest.fn(),
+  },
+};
+
+const contentDecoratorModuleMock = {
+  default: {
+    decorateItem: jest.fn(),
+    updateItemUI: jest.fn(),
+    computeId: jest.fn(() => null),
+  },
+};
+
+const domObserverModuleMock = {
+  default: {
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+  },
+};
+
+const pathAnalyzerEntityType = {
+  EPISODE: "episode",
+  SERIES: "series",
+  SEASON: "season",
+  MOVIE: "movie",
+};
+
+const pathAnalyzerModuleMock = {
+  default: {
+    analyze: jest.fn(),
+    EntityType: pathAnalyzerEntityType,
+    formatSeasonName: jest.fn(() => "Test Season"),
+    formatSeriesName: jest.fn(() => "Test Series"),
+  },
+};
+
+const uiManagerModuleMock = {
+  default: {
+    showToast: jest.fn(),
+    injectCSS: jest.fn(),
+  },
+};
+
+const i18nModuleMock = {
+  default: {
+    t: jest.fn((key) => key),
+    init: jest.fn(),
+  },
+};
+
+const errorHandlerModuleMock = {
+  default: jest.fn((fn) => fn()),
+};
+
+await jest.unstable_mockModule("../../src/utils.js", () => utilsModuleMock);
+await jest.unstable_mockModule("../../src/store.js", () => storeModuleMock);
+await jest.unstable_mockModule("../../src/settings.js", () => settingsModuleMock);
+await jest.unstable_mockModule("../../src/content-decorator.js", () => contentDecoratorModuleMock);
+await jest.unstable_mockModule("../../src/dom-observer.js", () => domObserverModuleMock);
+await jest.unstable_mockModule("../../src/path-analyzer.js", () => pathAnalyzerModuleMock);
+await jest.unstable_mockModule("../../src/ui-manager.js", () => uiManagerModuleMock);
+await jest.unstable_mockModule("../../src/i18n.js", () => i18nModuleMock);
+await jest.unstable_mockModule("../../src/error-handler.js", () => errorHandlerModuleMock);
+
+const { default: AppController } = await import("../../src/app-controller.js");
+
+const { propagateWatchingState } = AppController.__testables;
+
+const Store = storeModuleMock.default;
+const PathAnalyzer = pathAnalyzerModuleMock.default;
+const UIManager = uiManagerModuleMock.default;
+const I18n = i18nModuleMock.default;
+
+describe("propagateWatchingState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("keeps completed parents untouched", async () => {
+    PathAnalyzer.analyze.mockReturnValue({
+      isValid: true,
+      type: PathAnalyzer.EntityType.EPISODE,
+      hierarchy: {
+        seasonId: "season-1",
+        seriesId: "series-1",
+      },
+    });
+
+    Store.getStatus.mockImplementation((type) => {
+      if (type === "season") {
+        return STATE_COMPLETED;
+      }
+      if (type === "series") {
+        return STATE_COMPLETED;
+      }
+      return STATE_UNTRACKED;
+    });
+
+    await propagateWatchingState("/episode/foo");
+
+    expect(Store.setState).not.toHaveBeenCalled();
+    expect(UIManager.showToast).not.toHaveBeenCalled();
+  });
+
+  test("auto-tracks only untracked parents", async () => {
+    PathAnalyzer.analyze.mockReturnValue({
+      isValid: true,
+      type: PathAnalyzer.EntityType.EPISODE,
+      hierarchy: {
+        seasonId: "season-2",
+        seriesId: "series-2",
+      },
+    });
+
+    PathAnalyzer.formatSeasonName.mockReturnValue("Season Two");
+    PathAnalyzer.formatSeriesName.mockReturnValue("Series Two");
+
+    Store.getStatus.mockImplementation((type) => {
+      if (type === "season") {
+        return STATE_UNTRACKED;
+      }
+      if (type === "series") {
+        return STATE_UNTRACKED;
+      }
+      return STATE_UNTRACKED;
+    });
+
+    await propagateWatchingState("/episode/bar");
+
+    expect(Store.setState).toHaveBeenCalledTimes(2);
+    expect(Store.setState).toHaveBeenNthCalledWith(1, "season", "season-2", STATE_WATCHING, {
+      series_id: "series-2",
+      name: "Season Two",
+    });
+    expect(Store.setState).toHaveBeenNthCalledWith(2, "series", "series-2", STATE_WATCHING, {
+      name: "Series Two",
+    });
+    expect(UIManager.showToast).toHaveBeenCalledTimes(2);
+    expect(I18n.t).toHaveBeenCalledWith("toastAutoTrackSeason", { seasonName: "Season Two" });
+    expect(I18n.t).toHaveBeenCalledWith("toastAutoTrackSeries", { seriesName: "Series Two" });
+  });
+});


### PR DESCRIPTION
## Summary
- stop overwriting completed season and series entries when propagating episode toggles
- expose the propagateWatchingState helper for testing and add unit coverage for completed parents

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d68bb0295883329dff099acb869ed2